### PR TITLE
feat(github): allow defining custom redirect_url

### DIFF
--- a/src/module/src/runtime/server/routes/auth/github.get.ts
+++ b/src/module/src/runtime/server/routes/auth/github.get.ts
@@ -10,12 +10,12 @@ import { useRuntimeConfig } from '#imports'
 export interface OAuthGitHubConfig {
   /**
    * GitHub OAuth Client ID
-   * @default process.env.NUXT_OAUTH_GITHUB_CLIENT_ID
+   * @default process.env.STUDIO_GITHUB_CLIENT_ID
    */
   clientId?: string
   /**
    * GitHub OAuth Client Secret
-   * @default process.env.NUXT_OAUTH_GITHUB_CLIENT_SECRET
+   * @default process.env.STUDIO_GITHUB_CLIENT_SECRET
    */
   clientSecret?: string
   /**
@@ -58,8 +58,8 @@ export interface OAuthGitHubConfig {
 
   /**
    * Redirect URL to to allow overriding for situations like prod failing to determine public hostname
-   * @default process.env.NUXT_STUDIO_AUTH_GITHUB_REDIRECT_URL
-   * @see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps
+   * Use `process.env.STUDIO_GITHUB_REDIRECT_URL` to overwrite the default redirect URL.
+   * @default is ${hostname}/__nuxt_studio/auth/github
    */
   redirectURL?: string
 }
@@ -83,6 +83,7 @@ export default eventHandler(async (event: H3Event) => {
   const config = defu(useRuntimeConfig(event).studio?.auth?.github, {
     clientId: process.env.STUDIO_GITHUB_CLIENT_ID,
     clientSecret: process.env.STUDIO_GITHUB_CLIENT_SECRET,
+    redirectURL: process.env.STUDIO_GITHUB_REDIRECT_URL,
     authorizationURL: 'https://github.com/login/oauth/authorize',
     tokenURL: 'https://github.com/login/oauth/access_token',
     apiURL: 'https://api.github.com',


### PR DESCRIPTION
This allows users to define a custom github redirect url, which is particularly helpful for situations where determining a public hostname is not possible.