### PR TITLE
fix: handle `/` prefix in source

### DIFF
--- a/src/app/src/composables/useContext.ts
+++ b/src/app/src/composables/useContext.ts
@@ -139,19 +139,14 @@ export const useContext = createSharedComposable((
       }
     },
     [StudioItemActionId.RevertItem]: async (item: TreeItem) => {
-      // Get collections from document item or use default media collection
-      for (const collection of item.collections) {
-        const id = generateIdFromFsPath(item.fsPath, collection)
-        await activeTree.value.draft.revert(id)
-      }
+      await activeTree.value.draft.revert(item.id)
     },
     [StudioItemActionId.RenameItem]: async (params: TreeItem | RenameFileParams) => {
       const { item, newFsPath } = params as RenameFileParams
 
       // Revert file
       if (item.type === 'file') {
-        const id = generateIdFromFsPath(item.fsPath, item.collections[0])
-        await activeTree.value.draft.rename([{ id, newFsPath }])
+        await activeTree.value.draft.rename([{ id: item.id, newFsPath }])
         return
       }
 
@@ -160,7 +155,7 @@ export const useContext = createSharedComposable((
       if (descendants.length > 0) {
         const itemsToRename = descendants.map((descendant) => {
           return {
-            id: generateIdFromFsPath(descendant.fsPath, descendant.collections[0]),
+            id: descendant.id,
             newFsPath: descendant.fsPath.replace(item.fsPath, newFsPath),
           }
         })
@@ -171,25 +166,21 @@ export const useContext = createSharedComposable((
     [StudioItemActionId.DeleteItem]: async (item: TreeItem) => {
       // Delete file
       if (item.type === 'file') {
-        const id = generateIdFromFsPath(item.fsPath, item.collections![0])
-        await activeTree.value.draft.remove([id])
+        await activeTree.value.draft.remove([item.id])
         return
       }
 
       // Delete folder
       const descendants = findDescendantsFileItemsFromFsPath(activeTree.value.root.value, item.fsPath)
       if (descendants.length > 0) {
-        const ids: string[] = descendants.map((descendant) => {
-          return generateIdFromFsPath(descendant.fsPath, descendant.collections![0])
-        })
+        const ids: string[] = descendants.map(descendant => descendant.id)
         await activeTree.value.draft.remove(ids)
       }
     },
     [StudioItemActionId.DuplicateItem]: async (item: TreeItem) => {
       // Duplicate file
       if (item.type === 'file') {
-        const id = generateIdFromFsPath(item.fsPath, item.collections![0])
-        const draftItem = await activeTree.value.draft.duplicate(id)
+        const draftItem = await activeTree.value.draft.duplicate(item.id)
         await activeTree.value.selectItemByFsPath(draftItem!.id)
         return
       }

--- a/src/app/src/composables/useTree.ts
+++ b/src/app/src/composables/useTree.ts
@@ -2,7 +2,7 @@ import { StudioFeature, TreeStatus, type StudioHost, type TreeItem, DraftStatus 
 import { ref, computed } from 'vue'
 import type { useDraftDocuments } from './useDraftDocuments'
 import type { useDraftMedias } from './useDraftMedias'
-import { buildTree, findItemFromFsPath, findItemFromRoute, findParentFromFsPath, generateIdFromFsPath } from '../utils/tree'
+import { buildTree, findItemFromFsPath, findItemFromRoute, findParentFromFsPath } from '../utils/tree'
 import type { RouteLocationNormalized } from 'vue-router'
 import { useHooks } from './useHooks'
 import { useStudioState } from './useStudioState'
@@ -53,7 +53,7 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
     setLocation(type, currentItem.value.fsPath)
 
     if (item?.type === 'file') {
-      await draft.selectById(generateIdFromFsPath(item.fsPath, item.collections![0]))
+      await draft.selectById(item.id)
 
       if (
         !preferences.value.syncEditorAndRoute

--- a/src/app/src/types/tree.ts
+++ b/src/app/src/types/tree.ts
@@ -21,4 +21,5 @@ export interface TreeItem {
   routePath?: string
   children?: TreeItem[]
   hide?: boolean
+  id: string
 }

--- a/src/app/src/utils/tree.ts
+++ b/src/app/src/utils/tree.ts
@@ -81,6 +81,7 @@ TreeItem[] {
         type: 'file',
         prefix,
         collections: [dbItem.id.split('/')[0]],
+        id: dbItem.id,
       }
 
       if (dbItem.fsPath.endsWith('.gitkeep')) {
@@ -122,6 +123,7 @@ TreeItem[] {
           children: [],
           prefix: dirPrefix,
           collections: [dbItem.id.split('/')[0]],
+          id: dirFsPath,
         }
 
         directoryMap.set(dirFsPath, directory)
@@ -150,6 +152,7 @@ TreeItem[] {
       type: 'file',
       prefix,
       collections: [dbItem.id.split('/')[0]],
+      id: dbItem.id,
     }
 
     if (dbItem.fsPath.endsWith('.gitkeep')) {

--- a/src/module/src/runtime/utils/collection.ts
+++ b/src/module/src/runtime/utils/collection.ts
@@ -63,12 +63,11 @@ export function getCollection(collectionName: string, collections: Record<string
 }
 
 export function getCollectionSource(id: string, collection: CollectionInfo) {
-  const [_, ...rest] = id.split(/[/:]/)
-  const path = rest.join('/')
-
   const matchedSource = collection.source.find((source) => {
-    const include = minimatch(path, source.include, { dot: true })
-    const exclude = source.exclude?.some(exclude => minimatch(path, exclude))
+    const filePath = generateFsPathFromId(id, source)
+
+    const include = minimatch(filePath, source.include, { dot: true })
+    const exclude = source.exclude?.some(exclude => minimatch(filePath, exclude))
 
     return include && !exclude
   })
@@ -82,7 +81,7 @@ export function generateFsPathFromId(id: string, source: CollectionInfo['source'
 
   const { fixed } = parseSourceBase(source)
 
-  const pathWithoutFixed = path.substring(fixed.length)
+  const pathWithoutFixed = source.prefix === '/' ? path : path.substring(fixed.length)
   return join(fixed, pathWithoutFixed)
 }
 


### PR DESCRIPTION
This PR adds support for `prefix` in `source` for collections, which fixes the problem reported in #56 

The way this is implemented is to add a new `id` property to `TreeItem`, which allows the Studio app to rely on native IDs from `nuxt/content`, without having to duplicate or match the logic for generating those IDs. As a neat side effect, this might bring some slight performance benefits as some operations in the file tree no longer have to iterate. Also this removes a bunch of `items.collection![0]` assertions, which is nice too.

I think its noteworthy to say that `generateIdFromFsPath` from `tree.ts` still remains as there are some collection decoupled operations that still benefit from the basic idea of the function, however for collection item operations, I think it should be avoided.

The primary issue of generating the file path from the ID is also fixed by ensuring that the fixed part of the include pattern is not removed if the `prefix` is `/`.

**Note:** This is not yet an ideal solution as 
1. Users might want to define alternative prefixes than `/`
2. Data collectione receive a prefix defined as `/{collectionName}`, so this might need to be collection type aware. As per the Nuxt Content documentation, only page collections take use of the prefix, see https://github.com/nuxt/content/blob/87a2530e01b012be993d40eac3b310fdf5190882/docs/content/docs/2.collections/3.sources.md?plain=1#L45
3. Nuxt Studio currently breaks when trying to edit data collections, as it tries to navigate the page to a route that doesnt exist

