### PR TITLE
fix(app): only navigate to treeitems with routePath

### DIFF
--- a/src/app/src/composables/useTree.ts
+++ b/src/app/src/composables/useTree.ts
@@ -59,7 +59,7 @@ export const useTree = (type: StudioFeature, host: StudioHost, draft: ReturnType
         !preferences.value.syncEditorAndRoute
         || type === StudioFeature.Media
         || item.name === '.navigation'
-        || item.routePath === undefined
+        || !item.routePath
       ) {
         return
       }


### PR DESCRIPTION
This PR prevents the app from routing the host to an item in the tree that is not routable (i.e. has no routePath).
This is the case for items such as elements in a data collection, that have no 1:1 relation to a route.