### PR TITLE
chore(playground): configure studio for minimal playground

### DIFF
--- a/playground/minimal/nuxt.config.ts
+++ b/playground/minimal/nuxt.config.ts
@@ -10,4 +10,13 @@ export default defineNuxtConfig({
     },
   },
   compatibilityDate: '2025-08-26',
+  studio: {
+    repository: {
+      owner: 'nuxt-content',
+      repo: 'studio',
+      branch: 'main',
+      rootDir: 'playground/minimal',
+      private: false,
+    },
+  },
 })


### PR DESCRIPTION
Configures the minimal playground like the docus playground, with an adjusted rootDir.

This prevents slightly annoying alerts when working with the default config for minimal:

<img width="738" height="290" alt="image" src="https://github.com/user-attachments/assets/142e0437-bfb6-4c2b-bf5f-683c34eb79c9" />
