### PR TITLE
fix(styles): Improve dark mode text contrast

### DIFF
--- a/src/app/src/components/content/ContentEditorConflict.vue
+++ b/src/app/src/components/content/ContentEditorConflict.vue
@@ -117,7 +117,7 @@ useMonacoDiff(diffEditorRef, {
             </div>
           </dl>
 
-          <p class="text-xs mb-2">
+          <p class="text-muted text-xs mb-2">
             {{ $t('studio.conflict.description') }}
           </p>
         </div>


### PR DESCRIPTION
Before :

<img width="266" height="124" alt="Capture" src="https://github.com/user-attachments/assets/71bfa8a0-f1d2-4d32-ba0a-d90ea7efcf7f" />

After :

<img width="265" height="128" alt="Capture1" src="https://github.com/user-attachments/assets/bf0ca9fb-4918-43b7-b903-5bd4cde33c3a" />
