### PR TITLE
feat(i18n): diff toggle button in MDC alert

### DIFF
--- a/src/app/src/components/shared/AlertMDCFormatting.vue
+++ b/src/app/src/components/shared/AlertMDCFormatting.vue
@@ -37,7 +37,7 @@ function toggleAction() {
         class="bg-white hover:bg-muted dark:bg-accented dark:hover:bg-elevated"
         @click="toggleAction"
       >
-        {{ isDiffShown ? 'Back to code' : "See what's changed" }}
+        {{ isDiffShown ? $t('studio.buttons.backToCode') : $t('studio.buttons.seeChanges') }}
       </UButton>
     </template>
   </UAlert>

--- a/src/app/src/locales/en.json
+++ b/src/app/src/locales/en.json
@@ -8,7 +8,9 @@
       "signOut": "Sign out",
       "review": "Review",
       "publish": "Publish",
-      "back": "Back"
+      "back": "Back",
+      "backToCode": "Back to code",
+      "seeChanges": "See what's changed"
     },
     "headings": {
       "directories": "Directories",

--- a/src/app/src/locales/fr.json
+++ b/src/app/src/locales/fr.json
@@ -8,7 +8,9 @@
       "signOut": "Se déconnecter",
       "review": "Valider",
       "publish": "Publier",
-      "back": "Retour"
+      "back": "Retour",
+      "backToCode": "Retour au code",
+      "seeChanges": "Voir les changements"
     },
     "headings": {
       "directories": "Dossiers",


### PR DESCRIPTION
This PR internationalizes the 'See what's changed' / 'Back to code' button in the AlertMDCFormatting.vue component.

Adds the new translation keys studio.buttons.backToCode and studio.buttons.seeChanges to en.json and fr.json.