### PR TITLE
fix(i18n): Migrate locale fetching to useStudioHost()

### DIFF
--- a/src/app/src/utils/monaco/index.ts
+++ b/src/app/src/utils/monaco/index.ts
@@ -19,8 +19,9 @@ export const setupMonaco = createSingletonPromise(async () => {
     'ru',
     'it',
   ]
-  // @ts-expect-error - global property defined in the nuxt plugin
-  const locale: string = window.__NUXT_STUDIO_DEFAULT_LOCALE__ || 'en'
+
+  const host = window.useStudioHost()
+  const locale: string = host.meta.defaultLocale || 'en'
 
   let finalLocale: string
   if (locale === 'en') {


### PR DESCRIPTION
Replaces the deprecated direct reference to `window.__NUXT_STUDIO_DEFAULT_LOCALE__` by `window.useStudioHost()` utility.