### PR TITLE
fix(studio): resolve double-toggle event conflict on debug switch

### DIFF
--- a/src/app/src/components/AppFooter.vue
+++ b/src/app/src/components/AppFooter.vue
@@ -91,7 +91,7 @@ function closeStudio() {
       <template #debug-mode>
         <div
           class="w-full"
-          @click.stop="updatePreference('debug', !preferences.debug)"
+          @click.stop
         >
           <USwitch
             :model-value="preferences.debug"


### PR DESCRIPTION
Removes the redundant click handler on the wrapper `div` that was conflicting with the native `USwitch` update event. This fixes the issue where clicking the switch body would immediately revert the state due to event bubbling.

Before

https://github.com/user-attachments/assets/ef052ba4-182d-431b-b4a6-0ea438fe6e12

After

https://github.com/user-attachments/assets/f8d7ce5d-17fa-4f41-9ae0-f3b39fab636b