### PR TITLE
feat(gitlab): normalize instance URL by removing trailing slashes

### DIFF
--- a/src/app/src/utils/providers/gitlab.ts
+++ b/src/app/src/utils/providers/gitlab.ts
@@ -1,5 +1,5 @@
 import { ofetch } from 'ofetch'
-import { joinURL } from 'ufo'
+import { joinURL, withoutTrailingSlash } from 'ufo'
 import type { GitOptions, GitProviderAPI, GitFile, RawFile, CommitResult, CommitFilesOptions } from '../../types'
 import { DraftStatus } from '../../types/draft'
 import { StudioFeature } from '../../types'
@@ -9,7 +9,7 @@ export function createGitLabProvider(options: GitOptions): GitProviderAPI {
   const gitFiles: Record<string, GitFile> = {}
 
   // Remove trailing slash from instanceUrl if present
-  const normalizedInstanceUrl = instanceUrl.replace(/\/+$/, '')
+  const normalizedInstanceUrl = withoutTrailingSlash(instanceUrl)
 
   // GitLab uses project path (namespace/project) encoded as project ID
   const projectPath = encodeURIComponent(`${owner}/${repo}`)


### PR DESCRIPTION
It's not a particularly big change, but I always find it annoying when you forget and then have to rebuild. Since it's not mentioned anywhere. In this PR, I simply added that in the Gitlab configuration, the trailing slash in the instance URL is removed if it is present.