### PR TITLE
docs(setup): add missing languages to i18n documentation

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -191,6 +191,12 @@ Nuxt Studio includes built-in internationalization support with the following la
 - 🇧🇷 **Portuguese (Brazil)**
 - 🇺🇦 **Ukrainian**
 - 🇨🇳 **Chinese**
+- 🇰🇷 **Korean**
+- 🇨🇿 **Czech**
+- 🇳🇴 **Norwegian (Bokmål)**
+- 🇳🇴 **Norwegian (Nynorsk)**
+- 🇷🇺 **Russian**
+- 🇹🇼 **Taiwan (Chinese Traditional)**
 
 Set your preferred language using the `i18n` option:
 


### PR DESCRIPTION
docs(setup): add missing languages to i18n documentation

- Add `Korean`, `Czech`, `Norwegian (Bokmål)`, `Norwegian (Nynorsk)`, `Russian`, and `Taiwan (Chinese Traditional)` to the supported languages list (2.setup.md)

Thank you!:)