### PR TITLE
fix(collection): only match root sources in getCollectionByFilePath

### DIFF
--- a/src/module/src/runtime/utils/collection.ts
+++ b/src/module/src/runtime/utils/collection.ts
@@ -70,10 +70,10 @@ export function getCollectionByFilePath(path: string, collections: Record<string
     const paths = path === '/' ? ['index.yml', 'index.yaml', 'index.md', 'index.json'] : [path]
     return paths.some((p) => {
       matchedSource = collection.source.find((source) => {
+        const isRootSource = !source.prefix || source.prefix === '/'
         const include = minimatch(p, source.include, { dot: true })
         const exclude = source.exclude?.some(exclude => minimatch(p, exclude))
-
-        return include && !exclude
+        return isRootSource && include && !exclude
       })
 
       return matchedSource


### PR DESCRIPTION
## Summary

Thank you for maintaining this amazing project! 🙏

This PR fixes an issue where `getCollectionByFilePath` incorrectly matches files from the `content` directory to collections with non-root prefixes (e.g., `/docs`).

## Problem

When using multiple collections with different `cwd` values:

```typescript
// content.config.ts
const content = defineCollection({
  type: "page",
  source: "**/*.{md,yml,json}",  // content directory
})

const docs = defineCollection({
  type: "page",
  source: {
    include: "**/*.md",
    prefix: "/docs",
    cwd: "docs",  // docs directory
  },
})
```

Selecting a file like `content/dev-env-2026/index.md` in Studio throws:

```
Error: Collection not found for fsPath: dev-env-2026/index.md
```

### Root Cause

1. `getCollectionByFilePath` sorts collections by prefix length (longer first)
2. For `dev-env-2026/index.md`, the `docs` collection is checked first
3. `minimatch('dev-env-2026/index.md', '**/*.md')` returns `true`
4. The file is incorrectly assigned to the `docs` collection
5. `generateIdFromFsPath` creates an invalid ID
6. Database query fails

### Why `source.cwd` doesn't work

I initially tried filtering by `source.cwd`, but discovered that `@nuxt/content`'s `defineLocalSource` always sets `cwd: ""` at the end:

```javascript
const resolvedSource = {
  // ...
  ...source,
  cwd: ""  // Always empty!
}
```

## Solution

Filter sources by `source.prefix` instead:

```typescript
const isRootSource = !source.prefix || source.prefix === '/'
return isRootSource && include && !exclude
```

This ensures that files from the `content` directory (passed as relative paths) only match collections with root prefix (`/`).

## Testing

I couldn't find documentation on how to run the Studio editor locally for testing. So I verified this fix by:

1. Building the module with `dist/` included
2. Pushing the built `dist/` to my fork branch
3. Installing from GitHub in my project: `"nuxt-studio": "github:naitokosuke/nuxt-studio#fix/get-collection-by-file-path"`
4. Deploying to production and testing `/_studio` directly
5. Confirmed that selecting `content/dev-env-2026/index.md` no longer throws errors

If there's a recommended way to test Studio locally, I'd appreciate guidance for future contributions!

## Related

Fixes #235