### PR TITLE
fix(ItemCardForm): do not slugify whole path

### DIFF
--- a/src/app/src/components/shared/item/ItemCardForm.vue
+++ b/src/app/src/components/shared/item/ItemCardForm.vue
@@ -214,7 +214,7 @@ async function onSubmit() {
   isLoading.value = true
 
   let params: CreateFileParams | RenameFileParams | CreateFolderParams
-  const newFsPath = slugify(joinURL(props.parentItem.fsPath, fullName.value)).toLowerCase()
+  const newFsPath = joinURL(props.parentItem.fsPath, slugify(fullName.value)).toLowerCase()
 
   if (newFsPath === props.renamedItem?.fsPath) {
     isLoading.value = false


### PR DESCRIPTION
A recent fix in https://github.com/nuxt-content/nuxt-studio/pull/228 causes any file creation in a folder to be broken. 
This might be related to the rename / create issue I am experiencing in https://github.com/nuxt-content/nuxt-studio/issues/274

This change will perform the slugify call only on the newly entered fullName value of the path, which does not touch the fsPath context. `slugify` automatically removed the slashes from the whole joined path.

For example, previous to this change:
```
parentItem.fsPath: 3.pages/
fullName: example file.md
newFsPath: 3.pagesexample-file.md
```

After:
```
parentItem.fsPath: 3.pages/
fullName: example file.md
newFsPath: 3.pages/example-file.md
```
