### PR TITLE
Docs: Fixed GitLab Auth Provider Environment Secret Variable

### DIFF
--- a/docs/content/4.auth-providers.md
+++ b/docs/content/4.auth-providers.md
@@ -109,7 +109,7 @@ Add the GitLab OAuth credentials to your deployment platform's environment varia
 
 ```bash [.env]
 STUDIO_GITLAB_APPLICATION_ID=<your_gitlab_application_id>
-STUDIO_GITLAB_CLIENT_SECRET=<your_gitlab_secret>
+STUDIO_GITLAB_APPLICATION_SECRET=<your_gitlab_secret>
 # Optional: Restrict access to specific users
 # STUDIO_GITLAB_MODERATORS=admin@example.com,editor@example.com
 ```


### PR DESCRIPTION
Changed wrongfully documented env var `STUDIO_GITLAB_CLIENT_SECRET` to  `STUDIO_GITLAB_APPLICATION_SECRET` in docs.

See https://github.com/nuxt-content/nuxt-studio/blob/996aa7eb08b7f0e79f47bb57b74b803b0b4eb257/src/module/src/runtime/server/routes/auth/gitlab.get.ts#L95C36-L95C68