### PR TITLE
Improve labels for arrays of objects

### DIFF
--- a/src/app/src/components/form/input/InputArray.vue
+++ b/src/app/src/components/form/input/InputArray.vue
@@ -33,14 +33,17 @@ const items = computed(() => {
   }))
 })
 
+const LABEL_KEYS = ['title', 'label', 'name']
+
 function getItemLabel(item: unknown, index: number) {
   const isObject = itemsType.value === 'object'
     && typeof item === 'object'
     && item !== null
 
   if (isObject) {
-    const values = Object.values(item)
-    const firstString = values.find(value => typeof value === 'string')
+    const obj = item as Record<string, unknown>
+    const priorityValue = LABEL_KEYS.map(key => obj[key]).find(value => typeof value === 'string' && value)
+    const firstString = priorityValue ?? Object.values(obj).find(value => typeof value === 'string' && value)
     return `${index + 1}: ${firstString || '—'}`
   }
 


### PR DESCRIPTION
Currently, object inputs in arrays always have the label "Items" because they use the "items" key from the parent array's JSON schema object as the label. This creates awkward labelling for each object like "Items 1" which is grammatically incorrect ("Items" is plural but refers to a singular object), not helpful for labeling what that object contains, and does not use i18n.

This PR addresses these issues by changing how labels are generated for object inputs in arrays. The new logic grabs the first string value that the object contains, which will likely be a user-defined label or a key. This helps users identify each object at a glance. If no string exists yet, an emdash is used as a placeholder. For non-objects, the labeling logic is unchanged.