### PR TITLE
feat(studio): use slideover instead of popover, show all levels of props

### DIFF
--- a/src/app/src/components/form/FormInput.vue
+++ b/src/app/src/components/form/FormInput.vue
@@ -71,7 +71,6 @@ function computeValue(formItem: FormItem): unknown {
     <InputWrapper
       v-model="model"
       :form-item="formItem"
-      :level="1"
     />
   </UFormField>
 </template>

--- a/src/app/src/components/form/input/InputArray.vue
+++ b/src/app/src/components/form/input/InputArray.vue
@@ -9,9 +9,9 @@ const props = defineProps({
     type: Object as PropType<FormItem>,
     default: () => ({}),
   },
-  level: {
+  depth: {
     type: Number,
-    default: 1,
+    default: 0,
   },
 })
 
@@ -49,9 +49,6 @@ function getItemLabel(item: unknown, index: number) {
 
   return `${itemsLabel.value} ${index + 1}`
 }
-
-// Increment level for nested items
-const childLevel = computed(() => props.level + 1)
 
 function addItem() {
   const newItem = itemsType.value === 'object' ? {} : ''
@@ -161,7 +158,7 @@ function moveItem(index: number, offset: number) {
           <InputWrapper
             :model-value="item.value"
             :form-item="formItem"
-            :level="childLevel"
+            :depth="depth + 1"
             @update:model-value="updateItem(item.index, $event)"
           />
         </Collapsible>

--- a/src/app/src/components/form/input/InputObject.vue
+++ b/src/app/src/components/form/input/InputObject.vue
@@ -13,9 +13,9 @@ const props = defineProps({
     type: Object as PropType<FormTree>,
     default: null,
   },
-  level: {
+  depth: {
     type: Number,
-    default: 1,
+    default: 0,
   },
 })
 
@@ -24,28 +24,80 @@ const model = defineModel({
   default: (): Record<string, unknown> => ({}),
 })
 
-// Increment level for nested items
-const childLevel = computed(() => props.level + 1)
+/**
+ * FormTree keys use `:prop` for non-string props; parsed MDC / JSON values usually use plain `prop`.
+ */
+function collectKeyAliases(treeKey: string, child: FormItem): string[] {
+  const fromChild = child.key ?? treeKey
+  const variants = new Set<string>()
+  for (const k of [treeKey, fromChild]) {
+    if (!k) {
+      continue
+    }
+    variants.add(k)
+    if (k.startsWith(':')) {
+      variants.add(k.slice(1))
+    }
+    else {
+      variants.add(`:${k}`)
+    }
+  }
+  return [...variants]
+}
+
+function readChildValue(
+  model: Record<string, unknown> | undefined,
+  treeKey: string,
+  child: FormItem,
+): unknown {
+  if (!model) {
+    return child.default ?? getDefault(child.type)
+  }
+  for (const alias of collectKeyAliases(treeKey, child)) {
+    if (alias in model) {
+      return model[alias]
+    }
+  }
+  return child.default ?? getDefault(child.type)
+}
+
+function pickStorageKey(treeKey: string, child: FormItem, current: Record<string, unknown>): string {
+  for (const alias of collectKeyAliases(treeKey, child)) {
+    if (alias in current) {
+      return alias
+    }
+  }
+  const raw = child.key ?? treeKey
+  return raw.startsWith(':') ? raw.slice(1) : raw
+}
 
 const entries = computed(() => {
   if (!props.children) return []
 
   return Object.entries(props.children)
     .filter(([_, child]) => !child.hidden)
-    .map(([key, child]) => {
-      const value = model.value?.[key] ?? child.default ?? getDefault(child.type)
+    .map(([treeKey, child]) => {
+      const value = readChildValue(model.value, treeKey, child)
 
       return {
-        key,
-        label: titleCase(child.title || key),
+        key: treeKey,
+        label: titleCase(child.title || treeKey),
         value,
         formItem: child,
       }
     })
 })
 
-function updateValue(key: string, value: unknown) {
-  model.value = { ...model.value, [key]: value }
+function updateValue(treeKey: string, child: FormItem, value: unknown) {
+  const next = { ...model.value }
+  const storageKey = pickStorageKey(treeKey, child, next)
+  for (const alias of collectKeyAliases(treeKey, child)) {
+    if (alias !== storageKey && alias in next) {
+      Reflect.deleteProperty(next, alias)
+    }
+  }
+  next[storageKey] = value
+  model.value = next
 }
 
 function getDefault(type: string) {
@@ -65,7 +117,10 @@ function getDefault(type: string) {
 </script>
 
 <template>
-  <div class="space-y-2">
+  <div
+    class="space-y-2"
+    :class="depth > 1 ? 'border-l border-muted pl-3' : ''"
+  >
     <template v-if="entries.length">
       <UFormField
         v-for="entry in entries"
@@ -79,8 +134,8 @@ function getDefault(type: string) {
         <InputWrapper
           :model-value="entry.value"
           :form-item="entry.formItem"
-          :level="childLevel"
-          @update:model-value="updateValue(entry.key, $event)"
+          :depth="depth + 1"
+          @update:model-value="updateValue(entry.key, entry.formItem, $event)"
         />
       </UFormField>
     </template>

--- a/src/app/src/components/form/input/InputWrapper.vue
+++ b/src/app/src/components/form/input/InputWrapper.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import type { PropType } from 'vue'
 import type { FormItem } from '../../../types'
 import { typeComponentMap } from '../../../utils/form'
@@ -10,127 +10,38 @@ const props = defineProps({
     type: Object as PropType<FormItem>,
     required: true,
   },
-  level: {
+  depth: {
     type: Number,
-    required: true,
+    default: 0,
   },
 })
 
 const model = defineModel<unknown>({ required: true })
 
-// Nested form state for arrays/objects displayed as overlays
-const nestedFormOpen = ref(false)
-
-// Determine if this is a complex type that needs overlay
-const nestedForm = computed(() => {
-  if (props.level <= 2) return false
-
-  return props.formItem.type === 'array' || props.formItem.type === 'object'
-})
-
 // Get the appropriate input component
 const inputComponent = computed(() => typeComponentMap[props.formItem.type] ?? InputText)
-
-// Get display text for complex types
-const displayText = computed(() => {
-  if (props.formItem.type === 'array') {
-    const count = Array.isArray(model.value) ? model.value.length : 0
-    return { count, key: 'studio.tiptap.element.props.itemsCount' }
-  }
-  if (props.formItem.type === 'object') {
-    const count = props.formItem.children ? Object.keys(props.formItem.children).length : 0
-    return { count, key: 'studio.tiptap.element.props.fieldsCount' }
-  }
-  return null
-})
-
-function openNestedForm() {
-  nestedFormOpen.value = true
-}
-
-function closeNestedForm() {
-  nestedFormOpen.value = false
-}
 </script>
 
 <template>
-  <!-- Nested form overlay for arrays/objects -->
-  <template v-if="nestedForm && nestedFormOpen">
-    <div class="fixed inset-0 bg-default z-50 flex flex-col p-3 overflow-y-auto rounded-lg">
-      <div class="flex items-center justify-between mb-2">
-        <span class="text-sm font-mono font-semibold text-highlighted">
-          {{ formItem.title }}
-        </span>
-        <UButton
-          size="xs"
-          icon="i-lucide-x"
-          color="neutral"
-          variant="ghost"
-          aria-label="Close"
-          @click="closeNestedForm"
-        />
-      </div>
+  <InputObject
+    v-if="formItem.type === 'object'"
+    v-model="(model as Record<string, unknown>)"
+    :form-item="formItem"
+    :children="formItem.children || {}"
+    :depth="depth"
+  />
 
-      <InputArray
-        v-if="formItem.type === 'array'"
-        v-model="(model as unknown[])"
-        class="flex-1"
-        :form-item="formItem.arrayItemForm"
-        :level="level"
-      />
+  <InputArray
+    v-else-if="formItem.type === 'array'"
+    v-model="(model as unknown[])"
+    :form-item="formItem.arrayItemForm"
+    :depth="depth"
+  />
 
-      <InputObject
-        v-else-if="formItem.type === 'object'"
-        v-model="(model as Record<string, unknown>)"
-        class="flex-1"
-        :form-item="formItem"
-        :children="formItem.children || {}"
-        :level="level"
-      />
-    </div>
-  </template>
-
-  <!-- Array/Object button -->
-  <template v-else-if="nestedForm">
-    <div class="flex items-center gap-2">
-      <span
-        v-if="displayText"
-        class="text-xs text-muted"
-      >
-        {{ $t(displayText.key, { count: displayText.count }) }}
-      </span>
-      <UButton
-        size="xs"
-        color="neutral"
-        variant="link"
-        :label="$t('studio.tiptap.element.props.edit', { type: formItem.type })"
-        @click="openNestedForm"
-      />
-    </div>
-  </template>
-
-  <!-- Primitive types -->
-  <template v-else>
-    <InputObject
-      v-if="formItem.type === 'object'"
-      v-model="(model as Record<string, unknown>)"
-      :form-item="formItem"
-      :children="formItem.children || {}"
-      :level="level"
-    />
-
-    <InputArray
-      v-else-if="formItem.type === 'array'"
-      v-model="(model as unknown[])"
-      :form-item="formItem.arrayItemForm"
-      :level="level"
-    />
-
-    <component
-      :is="inputComponent"
-      v-else
-      v-model="model"
-      :form-item="formItem"
-    />
-  </template>
+  <component
+    :is="inputComponent"
+    v-else
+    v-model="model"
+    :form-item="formItem"
+  />
 </template>

--- a/src/app/src/components/tiptap/TiptapComponentProps.vue
+++ b/src/app/src/components/tiptap/TiptapComponentProps.vue
@@ -180,7 +180,7 @@ function normalizePropsTree(tree: FormTree): FormTree {
 
 <template>
   <div
-    class="p-3 min-w-[400px] max-w-[500px] not-prose overflow-y-auto max-h-[400px] relative"
+    class="p-3 w-full min-w-0 not-prose overflow-y-auto relative flex-1"
     @click.stop
   >
     <!-- Header -->

--- a/src/app/src/components/tiptap/TiptapComponentPropsSlideover.vue
+++ b/src/app/src/components/tiptap/TiptapComponentPropsSlideover.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DialogContentProps } from 'reka-ui'
+import { useSidebar } from '../../composables/useSidebar'
+
+defineProps<{
+  /** Shown in the slideover header when set (Nuxt UI `title` prop). */
+  title?: string
+}>()
+
+const { sidebarStyle } = useSidebar()
+
+const open = defineModel<boolean>('open', { default: false })
+
+/** DialogContent accepts inline `style` at runtime; reka-ui types omit it. */
+const slideoverContent = computed(() => ({ style: sidebarStyle.value }) as DialogContentProps)
+</script>
+
+<template>
+  <USlideover
+    v-model:open="open"
+    :title="title"
+    side="left"
+    :modal="false"
+    :content="slideoverContent"
+    :ui="{
+      content: 'p-0 max-w-none',
+      body: 'flex flex-col min-h-0 flex-1 overflow-hidden p-0 sm:p-0',
+    }"
+  >
+    <slot />
+
+    <template #body>
+      <slot name="body" />
+    </template>
+
+    <template
+      v-if="$slots.footer"
+      #footer
+    >
+      <slot name="footer" />
+    </template>
+  </USlideover>
+</template>

--- a/src/app/src/components/tiptap/extension/TiptapExtensionElement.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionElement.vue
@@ -150,7 +150,10 @@ function updateComponentProps(props: Record<string, unknown>) {
             />
           </UTooltip>
 
-          <UPopover v-model:open="openPropsPopover">
+          <TiptapComponentPropsSlideover
+            v-model:open="openPropsPopover"
+            :title="`${displayName} properties`"
+          >
             <UTooltip
               :text="$t('studio.tiptap.element.editProps')"
               :disabled="openPropsPopover"
@@ -166,13 +169,14 @@ function updateComponentProps(props: Record<string, unknown>) {
               />
             </UTooltip>
 
-            <template #content>
+            <template #body>
               <TiptapComponentProps
+                hide-title
                 :node="node"
                 :update-props="updateComponentProps"
               />
             </template>
-          </UPopover>
+          </TiptapComponentPropsSlideover>
 
           <UTooltip :text="$t('studio.tiptap.element.delete')">
             <UButton

--- a/src/app/src/components/tiptap/extension/TiptapExtensionImage.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionImage.vue
@@ -4,6 +4,7 @@ import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-3'
 import { useI18n } from 'vue-i18n'
 import type { ComponentMeta } from '../../../types'
 import TiptapComponentProps from '../TiptapComponentProps.vue'
+import TiptapComponentPropsSlideover from '../TiptapComponentPropsSlideover.vue'
 import { sanitizeMediaUrl } from '../../../utils/tiptap/props'
 
 const nodeProps = defineProps(nodeViewProps)
@@ -158,7 +159,10 @@ onMounted(() => {
         class="absolute top-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150"
         :class="{ 'opacity-100': isPopoverOpen || isSelected }"
       >
-        <UPopover v-model:open="isPopoverOpen">
+        <TiptapComponentPropsSlideover
+          v-model:open="isPopoverOpen"
+          :title="t('studio.tiptap.image.edit')"
+        >
           <UTooltip
             :text="t('studio.tiptap.image.edit') || 'Edit image'"
             :disabled="isPopoverOpen"
@@ -174,14 +178,15 @@ onMounted(() => {
             />
           </UTooltip>
 
-          <template #content>
+          <template #body>
             <TiptapComponentProps
+              hide-title
               :node="nodeProps.node"
               :update-props="updateImageAttributes"
               :override-meta="imageMeta"
             />
           </template>
-        </UPopover>
+        </TiptapComponentPropsSlideover>
 
         <UTooltip :text="t('studio.tiptap.image.delete')">
           <UButton

--- a/src/app/src/components/tiptap/extension/TiptapExtensionInlineElement.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionInlineElement.vue
@@ -7,6 +7,7 @@ import { useStudio } from '../../../composables/useStudio'
 import { isEmpty } from '../../../utils/object'
 import { standardNuxtUIComponents } from '../../../utils/tiptap/editor'
 import TiptapComponentProps from '../TiptapComponentProps.vue'
+import TiptapComponentPropsSlideover from '../TiptapComponentPropsSlideover.vue'
 
 const nodeProps = defineProps(nodeViewProps)
 
@@ -94,13 +95,13 @@ function handleKeyDown(event: KeyboardEvent) {
       />
     </div>
 
-    <UPopover
-      v-model:open="isPopoverOpen"
-      :ui="{ content: 'p-0' }"
-    >
-      <span />
-      <template #content>
-        <div class="flex flex-col min-w-80">
+    <TiptapComponentPropsSlideover v-model:open="isPopoverOpen">
+      <span
+        class="hidden"
+        aria-hidden="true"
+      />
+      <template #body>
+        <div class="flex flex-col min-h-0 w-full">
           <!-- Header with tabs -->
           <div class="flex items-center justify-between border-b border-default px-2 py-1.5">
             <div class="flex items-center gap-2">
@@ -157,7 +158,7 @@ function handleKeyDown(event: KeyboardEvent) {
           <!-- Edit Content -->
           <div
             v-if="activeTab === 'content' && hasDefaultSlot"
-            class="p-0.5 min-w-[400px] max-w-[500px]"
+            class="p-0.5 w-full min-w-0"
           >
             <UInput
               v-model="contentValue"
@@ -186,7 +187,7 @@ function handleKeyDown(event: KeyboardEvent) {
           <!-- Edit props -->
           <div
             v-else-if="activeTab === 'props'"
-            class="max-h-96 overflow-y-auto"
+            class="min-h-0 flex-1 overflow-y-auto"
           >
             <TiptapComponentProps
               :node="nodeProps.node"
@@ -196,6 +197,6 @@ function handleKeyDown(event: KeyboardEvent) {
           </div>
         </div>
       </template>
-    </UPopover>
+    </TiptapComponentPropsSlideover>
   </NodeViewWrapper>
 </template>

--- a/src/app/src/components/tiptap/extension/TiptapExtensionUCallout.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionUCallout.vue
@@ -125,6 +125,11 @@ const config = computed(() => {
   return base
 })
 const icon = computed(() => (componentProps.value.icon as string) || config.value.icon)
+
+const propsSlideoverTitle = computed(() => {
+  const label = CALLOUT_CONFIG[tag.value]?.label ?? 'Callout'
+  return `${label} properties`
+})
 const to = computed(() => componentProps.value.to as string | undefined)
 const isExternalTo = computed(() => !!to.value && to.value.startsWith('http'))
 
@@ -167,7 +172,10 @@ function onDelete(event: Event) {
           />
         </UTooltip>
 
-        <UPopover v-model:open="openPropsPopover">
+        <TiptapComponentPropsSlideover
+          v-model:open="openPropsPopover"
+          :title="propsSlideoverTitle"
+        >
           <UTooltip
             :text="$t('studio.tiptap.element.editProps')"
             :disabled="openPropsPopover"
@@ -183,13 +191,14 @@ function onDelete(event: Event) {
             />
           </UTooltip>
 
-          <template #content>
+          <template #body>
             <TiptapComponentProps
+              hide-title
               :node="node"
               :update-props="updateComponentProps"
             />
           </template>
-        </UPopover>
+        </TiptapComponentPropsSlideover>
 
         <UTooltip :text="$t('studio.tiptap.element.delete')">
           <UButton

--- a/src/app/src/components/tiptap/extension/TiptapExtensionVideo.vue
+++ b/src/app/src/components/tiptap/extension/TiptapExtensionVideo.vue
@@ -4,6 +4,7 @@ import { nodeViewProps, NodeViewWrapper, NodeViewContent } from '@tiptap/vue-3'
 import { useI18n } from 'vue-i18n'
 import type { ComponentMeta } from '../../../types'
 import TiptapComponentProps from '../TiptapComponentProps.vue'
+import TiptapComponentPropsSlideover from '../TiptapComponentPropsSlideover.vue'
 import { sanitizeMediaUrl } from '../../../utils/tiptap/props'
 
 const nodeProps = defineProps(nodeViewProps)
@@ -194,7 +195,10 @@ onMounted(() => {
         class="absolute top-2 right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150"
         :class="{ 'opacity-100': isPopoverOpen || isSelected }"
       >
-        <UPopover v-model:open="isPopoverOpen">
+        <TiptapComponentPropsSlideover
+          v-model:open="isPopoverOpen"
+          :title="t('studio.tiptap.video.edit')"
+        >
           <UTooltip
             :text="t('studio.tiptap.video.edit') || 'Edit video'"
             :disabled="isPopoverOpen"
@@ -210,14 +214,15 @@ onMounted(() => {
             />
           </UTooltip>
 
-          <template #content>
+          <template #body>
             <TiptapComponentProps
+              hide-title
               :node="nodeProps.node"
               :update-props="updateVideoAttributes"
               :override-meta="videoMeta"
             />
           </template>
-        </UPopover>
+        </TiptapComponentPropsSlideover>
 
         <UTooltip :text="t('studio.tiptap.video.delete')">
           <UButton


### PR DESCRIPTION
https://github.com/user-attachments/assets/701f010a-b0f6-4065-ba3d-927a0169e8b6

Fixes #435 

This one might be controversial. It's a change in the UX, especially when dealing with large lists & props.

Open for feedback!