### PR TITLE
fix(collection): guard against collections with empty or missing source

### DIFF
--- a/src/module/src/runtime/utils/collection.ts
+++ b/src/module/src/runtime/utils/collection.ts
@@ -13,6 +13,11 @@ export function generateStemFromFsPath(path: string) {
 }
 
 export function generateIdFromFsPath(path: string, collectionInfo: CollectionInfo) {
+  // Guard against collections without a source (e.g. the internal `info`
+  // collection from @nuxt/content, which serializes `source` as an empty array).
+  if (!collectionInfo.source?.length) {
+    return join(collectionInfo.name, path)
+  }
   const { fixed } = parseSourceBase(collectionInfo.source[0]!)
 
   const pathWithoutFixed = path.substring(fixed.length)
@@ -20,9 +25,13 @@ export function generateIdFromFsPath(path: string, collectionInfo: CollectionInf
   return join(collectionInfo.name, collectionInfo.source[0]?.prefix || '', pathWithoutFixed)
 }
 
-export function generateFsPathFromId(id: string, source: ResolvedCollectionSource) {
+export function generateFsPathFromId(id: string, source: ResolvedCollectionSource | undefined) {
   const [_, ...rest] = id.split(/[/:]/)
   let path = rest.join('/')
+
+  if (!source?.include) {
+    return path
+  }
 
   const { fixed } = parseSourceBase(source)
   const normalizedFixed = withoutTrailingSlash(fixed)

--- a/src/module/src/runtime/utils/source.ts
+++ b/src/module/src/runtime/utils/source.ts
@@ -3,7 +3,10 @@ import { withLeadingSlash, withoutLeadingSlash, withoutTrailingSlash } from 'ufo
 import { join } from 'pathe'
 import { minimatch } from 'minimatch'
 
-export function parseSourceBase(source: CollectionSource) {
+export function parseSourceBase(source: CollectionSource | undefined) {
+  if (!source?.include) {
+    return { fixed: '', dynamic: '' }
+  }
   const [fixPart, ...rest] = source.include.includes('*') ? source.include.split('*') : ['', source.include]
   return {
     fixed: fixPart || '',
@@ -21,6 +24,9 @@ export function getCollectionSourceById(id: string, sources: ResolvedCollectionS
   const prefixAndPath = rest.join('/')
 
   const matchedSource = sources.find((source) => {
+    if (!source?.include) {
+      return false
+    }
     const prefix = source.prefix
     if (typeof prefix !== 'string') {
       return false

--- a/src/module/test/utils/collection.test.ts
+++ b/src/module/test/utils/collection.test.ts
@@ -56,6 +56,11 @@ describe('getCollectionByFilePath', () => {
 })
 
 describe('generateFsPathFromId', () => {
+  it('should return path unchanged when source is undefined', () => {
+    const result = generateFsPathFromId('info/anything.md', undefined)
+    expect(result).toBe('anything.md')
+  })
+
   it('One file included', () => {
     const id = 'landing/index.md'
     const source = {
@@ -106,6 +111,16 @@ describe('generateFsPathFromId', () => {
 })
 
 describe('generateIdFromFsPath', () => {
+  it('should fall back to `{collectionName}/{path}` when collection has no source', () => {
+    const sourceLessCollection = {
+      name: 'info',
+      source: [],
+    } as unknown as CollectionInfo
+
+    const result = generateIdFromFsPath('anything.md', sourceLessCollection)
+    expect(result).toBe('info/anything.md')
+  })
+
   it('should generate id for single file with no prefix', () => {
     const path = 'index.md'
     const result = generateIdFromFsPath(path, collections.landing!)

--- a/src/module/test/utils/source.test.ts
+++ b/src/module/test/utils/source.test.ts
@@ -1,9 +1,30 @@
 import { describe, it, expect } from 'vitest'
-import { getCollectionSourceById } from '../../src/runtime/utils/source'
+import { getCollectionSourceById, parseSourceBase } from '../../src/runtime/utils/source'
 import { collections } from '../mocks/collection'
-import type { ResolvedCollectionSource } from '@nuxt/content'
+import type { CollectionSource, ResolvedCollectionSource } from '@nuxt/content'
+
+describe('parseSourceBase', () => {
+  it('should return empty fixed/dynamic when source is undefined', () => {
+    expect(parseSourceBase(undefined)).toEqual({ fixed: '', dynamic: '' })
+  })
+
+  it('should return empty fixed/dynamic when source has no include', () => {
+    expect(parseSourceBase({} as CollectionSource)).toEqual({ fixed: '', dynamic: '' })
+  })
+})
 
 describe('getCollectionSourceById', () => {
+  it('should skip sources without include (e.g. from @nuxt/content internal `info` collection)', () => {
+    const brokenSources = [
+      undefined,
+      {} as ResolvedCollectionSource,
+    ] as unknown as ResolvedCollectionSource[]
+
+    const source = getCollectionSourceById('info/anything.md', brokenSources)
+
+    expect(source).toBeUndefined()
+  })
+
   it('should return matching source for root docs collection', () => {
     const id = 'collectionName/1.getting-started/2.introduction.md'
     const source = getCollectionSourceById(id, collections.docs!.source)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #425 (paired with upstream fix nuxt/content#3771)

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`@nuxt/content` v3 exposes an internal \`info\` collection whose \`source\` is serialized as an empty array (\`source: []\`) in the preview manifest (see nuxt/content#3767). Studio iterates every collection via \`parseSourceBase\`, \`generateIdFromFsPath\`, and \`generateFsPathFromId\`, which all assumed at least one \`ResolvedCollectionSource\` entry — so the editor crashed with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'include')
    at parseSourceBase (source.js)
    …
TypeError: Cannot read properties of undefined (reading 'prefix')
    at generateIdFromFsPath (collection.js)
\`\`\`

The upstream payload fix (nuxt/content#3771) removes source-less collections from the preview manifest entirely, but these null guards are still the right shape defensively — Studio should tolerate any future source-less collection without corrupting the editor.

### What changed

- \`parseSourceBase\` now short-circuits to empty \`fixed\`/\`dynamic\` when the source (or its \`include\`) is missing.
- \`getCollectionSourceById\` skips sources without \`include\` during matching instead of throwing.
- \`generateIdFromFsPath\` falls back to \`join(name, path)\` when the collection has no source.
- \`generateFsPathFromId\` returns the raw path when no source is given.

### Tests

New cases added in \`src/module/test/utils/source.test.ts\` and \`src/module/test/utils/collection.test.ts\` covering each guarded path. \`pnpm vitest run src/module/test/utils/source.test.ts src/module/test/utils/collection.test.ts\` → **31/31 pass**. Full suite: 184 tests pass; the 5 unrelated file-level failures (\`document.test.ts\`, \`host.test.ts\`, \`draft-base.test.ts\`, \`compare.test.ts\`) are caused by \`nuxt-studio/app/utils\` resolution in the playground setup on \`main\` and are reproducible without this PR.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. *(no docs change needed — internal behavior only)*