### PR TITLE
fix(document): handle string-coerced navigation field from D1

### DIFF
--- a/src/module/src/runtime/utils/document/compare.ts
+++ b/src/module/src/runtime/utils/document/compare.ts
@@ -73,8 +73,8 @@ export function areDocumentsEqual(document1: Record<string, unknown>, document2:
     Reflect.deleteProperty(doc, '__hash__')
     Reflect.deleteProperty(doc, 'path')
 
-    // default value of navigation is true
-    if (typeof doc.navigation === 'undefined') {
+    // default value of navigation is true; D1 may store it as string 'true'
+    if (typeof doc.navigation === 'undefined' || doc.navigation === 'true') {
       doc.navigation = true
     }
 

--- a/src/module/src/runtime/utils/document/schema.ts
+++ b/src/module/src/runtime/utils/document/schema.ts
@@ -53,8 +53,9 @@ export function pickReservedKeysFromDocument(document: DatabaseItem): DatabaseIt
 
 export function cleanDataKeys(document: DatabaseItem): DatabaseItem {
   const result = omit(document, reservedKeys)
-  // Default value of navigation is true, so we can safely remove it
-  if (result.navigation === true) {
+  // Default value of navigation is true, so we can safely remove it.
+  // D1 may store booleans as strings, so handle both 'true' and true.
+  if (result.navigation === true || result.navigation === 'true') {
     Reflect.deleteProperty(result, 'navigation')
   }
 


### PR DESCRIPTION
## Description

D1/SQLite may store boolean `true` as the string `"true"` for the `navigation` field. Both `cleanDataKeys` and `areDocumentsEqual` only check for strict boolean `true`, missing the string variant.

## Problem

This causes two issues:

1. **cleanDataKeys**: The navigation field passes through as string `'true'` instead of being stripped. When serialized back to YAML/markdown frontmatter, this produces `navigation: 'true'` (a quoted string) instead of omitting it (since `true` is the default value and should not appear in the file).

2. **areDocumentsEqual**: When comparing documents, one may have boolean `true` (from the raw file) while the other has string `'true'` (from D1). This triggers a false "Updated" status indicator even though the content hasn't actually changed.

## Fix

Check for both `=== true` and `=== 'true'` in:
- `cleanDataKeys` (in `schema.ts`)
- `areDocumentsEqual` → `refineDocumentData` (in `compare.ts`)

## Changes

- `src/module/src/runtime/utils/document/schema.ts`: `cleanDataKeys` now also strips `navigation` when it's the string `'true'`
- `src/module/src/runtime/utils/document/compare.ts`: `refineDocumentData` normalizes string `'true'` to boolean `true` for navigation