### PR TITLE
fix(document): preserve extra seo fields when stripping redundant title/description

### DIFF
--- a/src/module/src/runtime/utils/document/schema.ts
+++ b/src/module/src/runtime/utils/document/schema.ts
@@ -59,12 +59,18 @@ export function cleanDataKeys(document: DatabaseItem): DatabaseItem {
   }
 
   if (document.seo) {
-    const seo = document.seo as Record<string, unknown>
-    if (
-      (!seo.title || seo.title === document.title)
-      && (!seo.description || seo.description === document.description)
-    ) {
+    const seo = { ...(document.seo as Record<string, unknown>) }
+    if (!seo.title || seo.title === document.title) {
+      Reflect.deleteProperty(seo, 'title')
+    }
+    if (!seo.description || seo.description === document.description) {
+      Reflect.deleteProperty(seo, 'description')
+    }
+    if (Object.keys(seo).length === 0) {
       Reflect.deleteProperty(result, 'seo')
+    }
+    else {
+      result.seo = seo
     }
   }
 


### PR DESCRIPTION
## Description

`cleanDataKeys` deletes the entire `seo` object when `seo.title` and `seo.description` match the document-level equivalents (or are empty). This silently discards any other SEO properties like `keywords`, `robots`, `canonical`, etc.

## Reproduction

```yaml
---
title: My Post
description: A summary.
seo:
  title: My Post
  description: A summary.
  keywords:
    - example
    - seo
---
```

After a Studio save round-trip, `seo` is completely gone — `keywords` lost.

## Root Cause

The condition checks whether `title` and `description` are redundant, then deletes the **entire object**:

```typescript
Reflect.deleteProperty(result, 'seo')
```

## Fix

Strip only the individually redundant fields (`title`, `description`). Delete the `seo` object only when nothing meaningful remains after stripping.

## Changes

- `src/module/src/runtime/utils/document/schema.ts`: `cleanDataKeys` now copies the seo object, removes redundant fields one-by-one, and only deletes the whole object if empty.

Fixes #401