### PR TITLE
fix(admin): use useRuntimeConfig instead of process.env for provider detection

### DIFF
--- a/src/module/src/runtime/server/routes/admin.ts
+++ b/src/module/src/runtime/server/routes/admin.ts
@@ -1,5 +1,5 @@
 import { eventHandler, getQuery, setCookie, sendRedirect, getRequestProtocol } from 'h3'
-import { createError } from '#imports'
+import { createError, useRuntimeConfig } from '#imports'
 
 export default eventHandler((event) => {
   const { redirect } = getQuery(event)
@@ -12,11 +12,15 @@ export default eventHandler((event) => {
     })
   }
 
-  // Detect providers based on configured environment variables
-  const hasGithub = process.env.STUDIO_GITHUB_CLIENT_ID && 'github'
-  const hasGitlab = process.env.STUDIO_GITLAB_APPLICATION_ID && 'gitlab'
-  const hasGoogle = process.env.STUDIO_GOOGLE_CLIENT_ID && 'google'
-  const hasSSO = (process.env.STUDIO_SSO_URL && process.env.STUDIO_SSO_CLIENT_ID && process.env.STUDIO_SSO_CLIENT_SECRET) && 'sso'
+  // Detect providers from runtimeConfig (populated at build time from env vars).
+  // Using runtimeConfig instead of process.env ensures this works on platforms
+  // where build-time env vars are not forwarded to the runtime (e.g. AWS Amplify).
+  const { studio } = useRuntimeConfig(event)
+  const auth = studio?.auth
+  const hasGithub = auth?.github?.clientId && 'github'
+  const hasGitlab = auth?.gitlab?.applicationId && 'gitlab'
+  const hasGoogle = auth?.google?.clientId && 'google'
+  const hasSSO = (auth?.sso?.serverUrl && auth?.sso?.clientId && auth?.sso?.clientSecret) && 'sso'
 
   const providers = [hasGithub, hasGitlab, hasGoogle, hasSSO].filter(Boolean)
   if (providers.length === 0) {

--- a/src/module/src/runtime/server/routes/admin.ts
+++ b/src/module/src/runtime/server/routes/admin.ts
@@ -13,8 +13,6 @@ export default eventHandler((event) => {
   }
 
   // Detect providers from runtimeConfig (populated at build time from env vars).
-  // Using runtimeConfig instead of process.env ensures this works on platforms
-  // where build-time env vars are not forwarded to the runtime (e.g. AWS Amplify).
   const { studio } = useRuntimeConfig(event)
   const auth = studio?.auth
   const hasGithub = auth?.github?.clientId && 'github'


### PR DESCRIPTION
## Description

The `/_studio` admin route handler reads `process.env` directly at runtime to detect which auth providers are configured. On platforms like AWS Amplify (and similar serverless platforms), environment variables are available during `nuxt build` but are **not forwarded** to the Lambda/function runtime.

This causes a 404 with `"No authentication provider found"` even though:
- The env vars exist at build time
- The module correctly populates `runtimeConfig.studio.auth` from those vars
- All other auth handlers already use `useRuntimeConfig()`

## Root Cause

```typescript
// admin.ts — reads process.env at runtime (broken on Amplify)
const hasGithub = process.env.STUDIO_GITHUB_CLIENT_ID && 'github'
```

Meanwhile `github.get.ts` correctly uses:
```typescript
const studioConfig = useRuntimeConfig(event).studio
```

## Fix

Replace `process.env.STUDIO_*` reads with `useRuntimeConfig(event).studio.auth.*` lookups, matching the pattern already used by all other auth route handlers.

## Changes

- `src/module/src/runtime/server/routes/admin.ts`: Use `useRuntimeConfig(event).studio.auth` for provider detection

Fixes #384